### PR TITLE
fix: Create output file directory if not exists

### DIFF
--- a/jasm-cli/src/main/java/me/darknet/assembler/cli/commands/CompileCommand.java
+++ b/jasm-cli/src/main/java/me/darknet/assembler/cli/commands/CompileCommand.java
@@ -172,9 +172,15 @@ public class CompileCommand implements Runnable {
                            outputPath = Paths.get(classFilename);
                         }
                         try {
+                            if (!Files.exists(outputPath)) {
+                                Files.createDirectories(outputPath.getParent());
+                                Files.createFile(outputPath);
+                            }
+
                             Files.write(outputPath, ((JavaClassRepresentation) representation).classFile());
                         } catch (IOException e) {
                             System.err.println("Failed to write output file: " + e.getMessage());
+                            e.printStackTrace();
                             System.exit(1);
                         }
                     }


### PR DESCRIPTION
Also prints out the stack trace in case something goes wrong for extra debuggability.