### PR TITLE
Per method lvt filter

### DIFF
--- a/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/JvmCompilerOptions.java
+++ b/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/JvmCompilerOptions.java
@@ -13,6 +13,8 @@ import dev.xdark.blw.version.JavaVersion;
 import org.jetbrains.annotations.NotNull;
 import org.objectweb.asm.ClassWriter;
 
+import java.util.Objects;
+
 public class JvmCompilerOptions implements CompilerOptions<JvmCompilerOptions> {
 
     protected int asmArgs;
@@ -21,6 +23,7 @@ public class JvmCompilerOptions implements CompilerOptions<JvmCompilerOptions> {
     protected String annotationPath;
     protected InheritanceChecker inheritanceChecker = ReflectiveInheritanceChecker.INSTANCE;
     protected JvmAnalysisEngineFactory engineProvider = TypedJvmAnalysisEngine::new;
+    private WriteLocalVariableFilter writeVariableFilter = WriteLocalVariableFilter.ALWAYS;
     private boolean doWriteVariables = true;
 
     public JvmCompilerOptions() {
@@ -102,12 +105,22 @@ public class JvmCompilerOptions implements CompilerOptions<JvmCompilerOptions> {
         return this;
     }
 
+    @Deprecated
     public boolean doWriteVariables() {
         return doWriteVariables;
     }
 
+    public @NotNull WriteLocalVariableFilter variableFilter() {
+        return writeVariableFilter;
+    }
+
+    public JvmCompilerOptions variableFilter(@NotNull WriteLocalVariableFilter writeVariableFilter) {
+        this.writeVariableFilter = Objects.requireNonNull(writeVariableFilter, "variableFilter");
+        return this;
+    }
+
     public JvmCompilerOptions doWriteVariables(boolean doWriteVariables) {
         this.doWriteVariables = doWriteVariables;
-        return this;
+        return variableFilter(doWriteVariables ? WriteLocalVariableFilter.ALWAYS : WriteLocalVariableFilter.NEVER);
     }
 }

--- a/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/WriteLocalVariableFilter.java
+++ b/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/WriteLocalVariableFilter.java
@@ -1,0 +1,19 @@
+package me.darknet.assembler.compile;
+
+import dev.xdark.blw.type.MethodType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Per method filter for local variable debug data.
+ *
+ * @see JvmCompilerOptions#variableFilter(WriteLocalVariableFilter)
+ */
+@FunctionalInterface
+public interface WriteLocalVariableFilter {
+
+    WriteLocalVariableFilter ALWAYS = (name, type) -> true;
+    WriteLocalVariableFilter NEVER = (name, type) -> false;
+
+    boolean shouldWriteVariables(@NotNull String name, @NotNull MethodType type);
+
+}

--- a/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/visitor/BlwClassVisitor.java
+++ b/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/visitor/BlwClassVisitor.java
@@ -106,7 +106,7 @@ public class BlwClassVisitor implements ASTClassVisitor {
         int accessFlags = BlwModifiers.getMethodModifiers(modifiers);
         MethodType type = Types.methodType(descriptor.literal());
         return new BlwMethodVisitor(
-                options, builder.type(), type, (accessFlags & AccessFlag.ACC_STATIC) == AccessFlag.ACC_STATIC,
+                options, builder.type(), name.literal(), type, (accessFlags & AccessFlag.ACC_STATIC) == AccessFlag.ACC_STATIC,
                 CastUtil.cast(builder.putMethod(accessFlags, name.literal(), type).child()),
                 analysisResults -> builder.setMethodAnalysis(name.literal(), type, analysisResults)
         );

--- a/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/visitor/BlwCodeVisitor.java
+++ b/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/visitor/BlwCodeVisitor.java
@@ -47,6 +47,8 @@ public class BlwCodeVisitor implements ASTJvmInstructionVisitor, JavaOpcodes {
     /**
      * @param options
      *                   Compiler option to pull values from.
+     * @param name
+     *                   Name of the method.
      * @param errorCollector
      *                   Collector for error reporting.
      * @param builder
@@ -57,14 +59,14 @@ public class BlwCodeVisitor implements ASTJvmInstructionVisitor, JavaOpcodes {
      *                   Parameter variables.
      */
     @SuppressWarnings("unchecked")
-    public BlwCodeVisitor(JvmCompilerOptions options, ErrorCollector errorCollector, CodeBuilder<?> builder, MethodType methodType, List<Local> parameters) {
+    public BlwCodeVisitor(JvmCompilerOptions options, String name, ErrorCollector errorCollector, CodeBuilder<?> builder, MethodType methodType, List<Local> parameters) {
         this.codeBuilder = builder;
         this.codeBuilderList = builder.codeList().child();
         this.checker = options.inheritanceChecker();
         this.errorCollector = errorCollector;
         this.analysisEngine = (JvmAnalysisEngine<Frame>) options.createEngine(varCache);
         this.parameters = parameters;
-        this.writeVariables = options.doWriteVariables();
+        this.writeVariables = options.variableFilter().shouldWriteVariables(name, methodType);
         this.methodType = methodType;
 
         analysisEngine.setErrorCollector(errorCollector);

--- a/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/visitor/BlwMethodVisitor.java
+++ b/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/visitor/BlwMethodVisitor.java
@@ -39,14 +39,16 @@ public class BlwMethodVisitor extends BlwMemberVisitor<MethodType, Method> imple
     private final List<Parameter> parameters = new ArrayList<>();
     private final MethodType type;
     private final ObjectType owner;
+    private final String name;
     private final boolean isStatic;
 
-    public BlwMethodVisitor(JvmCompilerOptions options, ObjectType owner, MethodType type, boolean isStatic,
+    public BlwMethodVisitor(JvmCompilerOptions options, ObjectType owner, String name, MethodType type, boolean isStatic,
             BlwReplaceMethodBuilder builder, Consumer<AnalysisResults> analysisResultsConsumer) {
         super(CastUtil.cast(builder));
         this.options = options;
         this.type = type;
         this.owner = owner;
+        this.name = name;
         this.isStatic = isStatic;
         this.builder = builder;
         this.analysisResultsConsumer = analysisResultsConsumer;
@@ -99,7 +101,7 @@ public class BlwMethodVisitor extends BlwMemberVisitor<MethodType, Method> imple
             }
         }
 
-        return new BlwCodeVisitor(options, collector, builder.code().child(), type, parameters) {
+        return new BlwCodeVisitor(options, name, collector, builder.code().child(), type, parameters) {
             @Override
             public void visitEnd() {
                 super.visitEnd();

--- a/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/visitor/BlwRootVisitor.java
+++ b/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/visitor/BlwRootVisitor.java
@@ -79,7 +79,7 @@ public record BlwRootVisitor(BlwReplaceClassBuilder builder, JvmCompilerOptions 
         int accessFlags = BlwModifiers.getMethodModifiers(modifiers);
         MethodType type = Types.methodType(descriptor.literal());
         return new BlwMethodVisitor(
-                options, builder.type(), type, (accessFlags & AccessFlag.ACC_STATIC) == AccessFlag.ACC_STATIC,
+                options, builder.type(), name.literal(), type, (accessFlags & AccessFlag.ACC_STATIC) == AccessFlag.ACC_STATIC,
                 CastUtil.cast(builder.putMethod(accessFlags, name.literal(), type).child()),
                 analysisResults -> builder.setMethodAnalysis(name.literal(), type, analysisResults)
         );


### PR DESCRIPTION
Add an option to write or not write the LVT per method.

2 things things I didn't want to decide:
I marked doWriteVariables as deprecated, depending on what the backwards compatibility plan for this maybe it should just be dropped?

I wasn't really sure where to put the WriteLocalVariableFilter, maybe a sub type in the options?