### PR TITLE
Add method based lvt filter

### DIFF
--- a/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/JvmCompilerOptions.java
+++ b/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/JvmCompilerOptions.java
@@ -11,6 +11,8 @@ import me.darknet.assembler.compiler.ReflectiveInheritanceChecker;
 import org.jetbrains.annotations.NotNull;
 import org.objectweb.asm.ClassWriter;
 
+import java.util.Objects;
+
 public class JvmCompilerOptions implements CompilerOptions<JvmCompilerOptions> {
     private static final int DEFAULT_VERSION = 8;
 
@@ -20,6 +22,7 @@ public class JvmCompilerOptions implements CompilerOptions<JvmCompilerOptions> {
     protected String annotationPath;
     protected InheritanceChecker inheritanceChecker = ReflectiveInheritanceChecker.INSTANCE;
     protected JvmAnalysisEngineFactory engineProvider = TypedJvmAnalysisEngine::new;
+    private WriteLocalVariableFilter writeVariableFilter = WriteLocalVariableFilter.ALWAYS;
     private boolean doWriteVariables = true;
 
     public JvmCompilerOptions() {
@@ -101,12 +104,22 @@ public class JvmCompilerOptions implements CompilerOptions<JvmCompilerOptions> {
         return this;
     }
 
+    @Deprecated
     public boolean doWriteVariables() {
         return doWriteVariables;
     }
 
+    public @NotNull WriteLocalVariableFilter variableFilter() {
+        return writeVariableFilter;
+    }
+
+    public JvmCompilerOptions variableFilter(@NotNull WriteLocalVariableFilter writeVariableFilter) {
+        this.writeVariableFilter = Objects.requireNonNull(writeVariableFilter, "variableFilter");
+        return this;
+    }
+
     public JvmCompilerOptions doWriteVariables(boolean doWriteVariables) {
         this.doWriteVariables = doWriteVariables;
-        return this;
+        return variableFilter(doWriteVariables ? WriteLocalVariableFilter.ALWAYS : WriteLocalVariableFilter.NEVER);
     }
 }

--- a/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/WriteLocalVariableFilter.java
+++ b/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/WriteLocalVariableFilter.java
@@ -1,0 +1,19 @@
+package me.darknet.assembler.compile;
+
+import org.jetbrains.annotations.NotNull;
+import org.objectweb.asm.Type;
+
+/**
+ * Per method filter for local variable debug data.
+ *
+ * @see JvmCompilerOptions#variableFilter(WriteLocalVariableFilter)
+ */
+@FunctionalInterface
+public interface WriteLocalVariableFilter {
+
+    WriteLocalVariableFilter ALWAYS = (name, type) -> true;
+    WriteLocalVariableFilter NEVER = (name, type) -> false;
+
+    boolean shouldWriteVariables(@NotNull String name, @NotNull Type type);
+
+}

--- a/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/visitor/JvmCodeVisitor.java
+++ b/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/visitor/JvmCodeVisitor.java
@@ -71,7 +71,7 @@ public class JvmCodeVisitor implements ASTJvmInstructionVisitor, Opcodes {
 		this.method = method;
 		this.errorCollector = errorCollector;
 		this.parameters = parameters;
-		this.writeVariables = options.doWriteVariables();
+		this.writeVariables = options.variableFilter().shouldWriteVariables(method.name, Type.getMethodType(method.desc));
 		parameters.stream().filter(Objects::nonNull).forEach(param -> {
 			VarCache.Variable parameterVar = varCache.getOrCreate(param.name(), param.index(), param.size() > 1);
 			parameterVar.updateTypeHint(param.type());


### PR DESCRIPTION
Add an option to write or not write the LVT per method.

2 things things I didn't want to decide:
I marked doWriteVariables as deprecated, depending on what the backwards compatibility plan for this maybe it should just be dropped?

I wasn't really sure where to put the WriteLocalVariableFilter, maybe a sub type in the options?