### PR TITLE
don't throw npe when outpath has no parent

### DIFF
--- a/jasm-cli/src/main/java/me/darknet/assembler/cli/commands/CompileCommand.java
+++ b/jasm-cli/src/main/java/me/darknet/assembler/cli/commands/CompileCommand.java
@@ -183,7 +183,10 @@ public class CompileCommand implements Runnable {
                            outputPath = Paths.get(classFilename);
                         }
                         try {
-                            Files.createDirectories(outputPath.getParent());
+                            Path parent = outputPath.getParent();
+                            if(parent != null){
+                               Files.createDirectories(parent);
+                            }
                             Files.write(outputPath, ((JavaClassRepresentation) representation).classFile());
                         } catch (IOException e) {
                             System.err.println("Failed to write output file: " + e.getMessage());


### PR DESCRIPTION
I tried to launch it with a very simple config like `compile -bv 8 -o=MMain.class /home/test.jasm` and I got an npe - I'm sending a fix